### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,12 +6,12 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ArtNode		KEYWORD1
+ArtNode	KEYWORD1
 ArtConfig	KEYWORD1
 
-ArtPoll		KEYWORD1
+ArtPoll	KEYWORD1
 ArtPollReply	KEYWORD1
-ArtDmx		KEYWORD1
+ArtDmx	KEYWORD1
 ArtAddress	KEYWORD1
 ArtIpProg	KEYWORD1
 
@@ -19,17 +19,17 @@ ArtIpProg	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getPort
-createPollReply
+getPort	KEYWORD2
+createPollReply	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-OpPoll		LITERAL1
+OpPoll	LITERAL1
 OpPollReply	LITERAL1
-OpDmx		LITERAL1
-OpSync		LITERAL1
+OpDmx	LITERAL1
+OpSync	LITERAL1
 OpAddress	LITERAL1
 OpIpProg	LITERAL1
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords